### PR TITLE
Brand Table Addition and its CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { AppService } from './app.service';
 import { User } from './users/entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { BrandsModule } from './brands/brands.module';
+import { Brand } from './brands/entities/brand.entity';
 
 @Module({
   imports: [
@@ -23,13 +25,14 @@ import { AuthModule } from './auth/auth.module';
         username: configService.get<string>('DB_USERNAME'),
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_DATABASE'),
-        entities: [User],
+        entities: [User, Brand],
         synchronize: true,
       }),
       inject: [ConfigService],
     }),
     UsersModule,
     AuthModule,
+    BrandsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/get-user.decorator.ts
+++ b/src/auth/get-user.decorator.ts
@@ -1,0 +1,10 @@
+// src/auth/get-user.decorator.ts
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '../users/entities/user.entity';
+
+export const GetUser = createParamDecorator(
+  (_data, ctx: ExecutionContext): User => {
+    const req = ctx.switchToHttp().getRequest();
+    return req.user;
+  },
+);

--- a/src/brands/brands.controller.ts
+++ b/src/brands/brands.controller.ts
@@ -1,0 +1,59 @@
+// src/brands/brands.controller.ts
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { BrandsService } from './brands.service';
+import { CreateBrandDto } from './dto/create-brand.dto';
+import { UpdateBrandDto } from './dto/update-brand.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../users/entities/user-role.enum';
+import { GetUser } from '../auth/get-user.decorator';
+import { User } from '../users/entities/user.entity';
+
+@Controller('brands')
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+export class BrandsController {
+  constructor(private readonly brandsService: BrandsService) {}
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  create(@Body() createBrandDto: CreateBrandDto, @GetUser() user: User) {
+    return this.brandsService.create(createBrandDto, user);
+  }
+
+  @Get()
+  @Roles(UserRole.ADMIN)
+  findAll() {
+    return this.brandsService.findAll();
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN)
+  findOne(@Param('id') id: string) {
+    return this.brandsService.findOne(id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN)
+  update(@Param('id') id: string, @Body() updateBrandDto: UpdateBrandDto) {
+    return this.brandsService.update(id, updateBrandDto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id') id: string) {
+    return this.brandsService.remove(id);
+  }
+}

--- a/src/brands/brands.module.ts
+++ b/src/brands/brands.module.ts
@@ -1,0 +1,13 @@
+// src/brands/brands.module.ts
+import { Module } from '@nestjs/common';
+import { BrandsService } from './brands.service';
+import { BrandsController } from './brands.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Brand } from './entities/brand.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Brand])], 
+  controllers: [BrandsController],
+  providers: [BrandsService],
+})
+export class BrandsModule {}

--- a/src/brands/brands.service.ts
+++ b/src/brands/brands.service.ts
@@ -1,0 +1,51 @@
+// src/brands/brands.service.ts
+
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Brand } from './entities/brand.entity';
+import { CreateBrandDto } from './dto/create-brand.dto';
+import { UpdateBrandDto } from './dto/update-brand.dto';
+import { User } from '../users/entities/user.entity';
+
+@Injectable()
+export class BrandsService {
+  constructor(
+    @InjectRepository(Brand)
+    private brandsRepository: Repository<Brand>,
+  ) {}
+
+  create(createBrandDto: CreateBrandDto, user: User): Promise<Brand> {
+    const newBrand = this.brandsRepository.create({
+      ...createBrandDto,
+      createdBy: user, // Link the brand to the user who created it
+    });
+    return this.brandsRepository.save(newBrand);
+  }
+
+  findAll(): Promise<Brand[]> {
+    return this.brandsRepository.find();
+  }
+
+  async findOne(id: string): Promise<Brand> {
+    const brand = await this.brandsRepository.findOneBy({ id });
+    if (!brand) {
+      throw new NotFoundException(`Brand with ID "${id}" not found`);
+    }
+    return brand;
+  }
+
+  async update(id: string, updateBrandDto: UpdateBrandDto): Promise<Brand> {
+    // We use findOne to leverage the NotFoundException if the brand doesn't exist
+    const brand = await this.findOne(id); 
+    const updatedBrand = Object.assign(brand, updateBrandDto);
+    return this.brandsRepository.save(updatedBrand);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.brandsRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Brand with ID "${id}" not found`);
+    }
+  }
+}

--- a/src/brands/dto/create-brand.dto.ts
+++ b/src/brands/dto/create-brand.dto.ts
@@ -1,0 +1,7 @@
+// src/brands/dto/create-brand.dto.ts
+
+export class CreateBrandDto {
+  name: string;
+  description: string;
+  logoUrl: string;
+}

--- a/src/brands/dto/update-brand.dto.ts
+++ b/src/brands/dto/update-brand.dto.ts
@@ -1,0 +1,7 @@
+// src/brands/dto/update-brand.dto.ts
+
+export class UpdateBrandDto {
+  name?: string;
+  description?: string;
+  logoUrl?: string;
+}

--- a/src/brands/entities/brand.entity.ts
+++ b/src/brands/entities/brand.entity.ts
@@ -1,0 +1,35 @@
+// src/brands/entities/brand.entity.ts
+
+import { User } from '../../users/entities/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Brand {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  description: string;
+
+  @Column()
+  logoUrl: string;
+
+  @ManyToOne(() => User)
+  createdBy: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
What's added:
1. Brand Entity: Adds a Brand table with a createdBy relationship to the User table.
2. Admin-Only CRUD APIs: Implements the full set of CRUD endpoints (POST, GET, PATCH, DELETE) under the /brands route.
3. Role-Based Security: Protects all brand-related endpoints, ensuring they can only be accessed by users with the ADMIN role.

Loom Demo: https://www.loom.com/share/a62930a37f1c4560bd0d9e5a494c302e?sid=b812df3d-5495-4562-bf82-86b05de5b4c2
Loom (Delete Operation): https://www.loom.com/share/ff8ab5116367470d931dac861f8cd743?sid=5fa150ef-cabf-420e-aabe-4b86d71ed220

Hoppscotch URL:
Brand create: https://hopp.sh/r/ovgbthsSraRl
Update brand: https://hopp.sh/r/piSQC5adLw3q
Get all brands: https://hopp.sh/r/l1eNG9nuwNOr
Delete brand: https://hopp.sh/r/rNnL4HUQ4uY6